### PR TITLE
Shipping estimator empty logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # USPS Shipping (RESTful) for Zen Cart
 
-![Coded with PHP](https://img.shields.io/badge/php-purple?style=flat&logo=php&logoColor=white&labelColor=black)  ![License via GPL 3.0](https://img.shields.io/badge/license-GPL-black?style=flat&logoColor=black&label=license&labelColor=black&color=purple)
-  ![Last Commit](https://badgen.net/github/last-commit/retched/ZC-USPSRestful?color=purple&labelColor=white)  ![Latest Release](https://badgen.net/github/release/retched/ZC-USPSRestful/stable?color=purple&labelColor=black&labelColor=white)
+![Coded with PHP](https://img.shields.io/badge/php-purple?style=flat&logo=php&logoColor=white&labelColor=black)  ![License via GPL 3.0](https://img.shields.io/badge/license-GPL-black?style=flat&logoColor=black&label=license&labelColor=black&color=851185) ![Last Commit](https://badgen.net/github/last-commit/retched/ZC-USPSRestful?color=851185&labelColor=white)  ![Latest Release](https://badgen.net/github/release/retched/ZC-USPSRestful/stable?color=851185&labelColor=black&labelColor=white)
 
-This module provides sellers a chance to offer United States Postal Service (USPS) shipping rates to customers during checkout. This is done by pulling the rates directly from the USPS' REST API.
+This module provides sellers the ability to offer United States Postal Service (USPS) shipping rates to their customers during checkout. This is done by pulling the rates directly from the USPS' REST API.
 
 This module supports versions 1.5.8 onward innately. (Support from 1.5.7 and backward is not necessarily guaranteed but is plausible. Read the Installation steps below for more details.) This script was primarily written with PHP8 in mind. (It might have problems working with PHP7.)
 
 ## Current Version: 0.1.1
-
-This is the initial version of the new USPS RESTful Module for ZenCart.
 
 ## Version History
 
@@ -20,7 +17,7 @@ This is the initial version of the new USPS RESTful Module for ZenCart.
     First "release".
 
 - 0.1.1
-    Various bugfixing including the reintroduction of First Class Mail Package International Service to the quote pool. There are limits to this service. Namely that the package and order value cannot be too high or else First Class Mail International cannot be used if the order is more than $400 USD.
+    Various bugfixing including the reintroduction of First Class Mail Package International Service to the quote pool.
 
 ## Additional Links
 
@@ -107,7 +104,7 @@ Those symbols don't appear within the new USPS API calls like they do on the ori
 If these settings are present:
 
 - On installation of the module, the script will convert the "default" box measurements to the measurement of the cart. If you chose to measure in centimeters, the script will multiply all measurements by 2.54 and will set those as the default size. During checkout, any number input there will be divided by 2.54 to reverse from centimeters to inches. That number will be sent along with the order details to make up the quote. If it's in inches, no conversion will be done.
-- During checkout with a cart configured with kilograms as the cart's weight, the total weight of the cart will be divided by (approximately) 2.205 to obtain the total number of pounds and will dispatch that as part of the quoting process. 
+- During checkout with a cart configured with kilograms as the cart's weight, the total weight of the cart will be divided by (approximately) 2.205 to obtain the total number of pounds and will dispatch that as part of the quoting process.
 
 The USPS API needs the size and weight values to be sent in imperial units.
 

--- a/zc_plugins/USPSRestful/v0.1.1/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.1.1/catalog/includes/modules/shipping/uspsr.php
@@ -1323,7 +1323,7 @@ class uspsr extends base
             /**
              * Is this package going to a APO/FPO/DPO?
              */
-            $this->is_apo_dest = in_array(uspsr_validate_zipcode($order->delivery['postcode']), self::USPSR_MILITARY_MAIL_ZIP);
+            $this->is_apo_dest = in_array(uspsr_validate_zipcode($order->delivery['postcode'] ?? '00000'), self::USPSR_MILITARY_MAIL_ZIP);
 
             /**
              * Check to see if the products in the cart are ALL eligible for USPS Media Mail.
@@ -1331,11 +1331,11 @@ class uspsr extends base
             if ($this->enable_media_mail) { $mailClasses[] = "MEDIA_MAIL"; }
 
             // Check to see if the order fits for USPS Connect Local
-            if (uspsr_check_connect_local($order->delivery['postcode'])) $mailClasses[] = "USPS_CONNECT_LOCAL";
+            if (uspsr_check_connect_local($order->delivery['postcode'] ?? '00000')) $mailClasses[] = "USPS_CONNECT_LOCAL";
 
             $json_body = [
                 'originZIPCode' => uspsr_validate_zipcode(SHIPPING_ORIGIN_ZIP),
-                'destinationZIPCode' => uspsr_validate_zipcode($order->delivery['postcode']),
+                'destinationZIPCode' => uspsr_validate_zipcode($order->delivery['postcode'] ?? '00000'),
                 'weight' => $shipping_weight,
                 'length' => $domm_length,
                 'width' => $domm_width,
@@ -1349,7 +1349,7 @@ class uspsr extends base
             // Let's make a standards request now.
             $standards_query = [
                 'originZIPCode' => uspsr_validate_zipcode(SHIPPING_ORIGIN_ZIP),
-                'destinationZIPCode' => uspsr_validate_zipcode($order->delivery['postcode']),
+                'destinationZIPCode' => uspsr_validate_zipcode($order->delivery['postcode'] ?? '00000'),
                 'mailClass' => 'ALL',
                 'weight' => $shipping_weight
             ];

--- a/zc_plugins/USPSRestful/v0.1.1/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.1.1/catalog/includes/modules/shipping/uspsr.php
@@ -718,6 +718,12 @@ class uspsr extends base
          *
          */
 
+        $message = '';
+        $message .= "\n" . '===============================================' . "\n";
+        $message .= 'Revoking Bearer Token...' . "\n";
+        $this->uspsrDebug($message);
+
+
         $this->revokeBearerToken();
 
         return $this->quotes;

--- a/zc_plugins/USPSRestful/v0.1.1/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.1.1/catalog/includes/modules/shipping/uspsr.php
@@ -153,7 +153,7 @@ class uspsr extends base
 
     protected $commError, $commErrNo, $commInfo;
 
-    private const USPSR_CURRENT_VERSION = '0.1.0';
+    private const USPSR_CURRENT_VERSION = '0.1.1';
 
     /**
      * This holds all of the USPS Zip Codes which are either APO (Air/Army Post Office), FPOs (Fleet Post Office), and

--- a/zc_plugins/USPSRestful/v0.1.1/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.1.1/catalog/includes/modules/shipping/uspsr.php
@@ -7,7 +7,7 @@
  * @copyright Portions Copyright 2004-2024 Zen Cart Team
  * @copyright Portions adapted from 2012 osCbyJetta
  * @author Paul Williams (retched)
- * @version $Id: uspsr.php 2024-12-22 retched Version 0.1.1 $
+ * @version $Id: uspsr.php 2025-01-16 retched Version 0.1.1 $
 ****************************************************************************
     USPS Shipping (RESTful) for Zen Cart
     A shipping module for ZenCart, an ecommerce platform


### PR DESCRIPTION
Fixes #9 

Resolves error by making the destination zip code 00000 until the customer uses the shipping estimator.