### PR TITLE
Crash out in 155

### DIFF
--- a/README.html
+++ b/README.html
@@ -396,7 +396,7 @@
 <ul>
     <li>
         1.1.3<br />
-        Fixed an issue where estimated dates and travel times were posted twice as part of the quote.
+        Fixed an issue where estimated dates and travel times were posted twice as part of the quote. Fixed an issue regarding compatibility with older versions of ZenCart.
     </li>
     <li>
         1.1.2<br />

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Released March 7, 2025 for ZenCart 2.1.0._
 ### Version/Release History
 
 - 1.1.3  
-  Fixed an issue where estimated dates and travel times were posted twice as part of the quote.
+  Fixed an issue where estimated dates and travel times were posted twice as part of the quote. Fixed an issue regarding compatibility with older versions of ZenCart.
 - 1.1.2  
   Bugfix to mend selection criteria being ignored during normal ZenCart checkout. (A shipping method would be selected but would be ignored in favor or the "first" shipping method listed.)
 - 1.1.1  

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - Fixed an issue where the estimated delivery and estimated day count would repeat twice. (Ex: "USPS (Priority Mail [est. delivery 03/09/2025] [est. delivery 03/09/2025])) Still not sure where it came from but it's resolved. [#36](https://github.com/retched/ZC-USPSRestful/issues/36)
+- Fixed an issue where an older version of ZenCart would try to invoke zen_db_perform with capitalized commands (`UPDATE` instead of `update`) and ZC just doesn't know what to do. [#40](https://github.com/retched/ZC-USPSRestful/issues/40)
 
 ## [1.1.2] - 2025-03-07
 

--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -2605,7 +2605,7 @@ class uspsr extends base
         // Add the last updated value to be updated to now()
         $sql_data_array['last_modified'] = "now()";
 
-        zen_db_perform(TABLE_CONFIGURATION, $sql_data_array, 'UPDATE', "configuration_key = '$key_name'");
+        zen_db_perform(TABLE_CONFIGURATION, $sql_data_array, 'update', "configuration_key = '$key_name'");
     }
 
     protected function addConfigurationKey($key_name, $value_array)
@@ -3225,4 +3225,15 @@ function zen_cfg_uspsr_numericupdown($key_value, $key = '')
     $output_str = zen_draw_input_field($key, $key_value, 'class="form-control" min="0" step="1"', FALSE, 'number');
 
     return $output_str;
+}
+
+// Compatibility for ZC 1.5.5
+if(!function_exists('zen_cfg_read_only')) {
+    function zen_cfg_read_only($text, $key = '')
+    {
+        $name = (!empty($key)) ? 'configuration[' . $key . ']' : 'configuration_value';
+        $text = htmlspecialchars_decode($text, ENT_COMPAT);
+
+        return $text . zen_draw_hidden_field($name, $text);
+    }
 }


### PR DESCRIPTION
# Description

Bugfix to clear problem with missing functions and crashes that happens in earlier version of ZenCart.

Fixes #40 

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (not in PHP nor ZenCart)
- Individual ZenCart Tests
  - [x] ZenCart 1.5.5
  - [x] ZenCart 1.5.6
  - [x] ZenCart 1.5.7
  - [x] ZenCart 1.5.8
  - [x] ZenCart 2.0.0
  - [x] ZenCart 2.0.1
  - [x] ZenCart 2.1.0
