### PR TITLE
Re-add four cents difference between metered and non-metered letters

### DIFF
--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -389,6 +389,10 @@ class uspsr extends base
             $_letter['rates'][0]['mailClass'] .= "_" . strtoupper(MODULE_SHIPPING_USPSR_LTR_PROCESSING);
             $_letter['rates'][0]['productName'] = ($this->usps_countries == 'US' ? 'First-Class Mail Letter' : 'First-Class Mail International Letter' );
             $_letter['rates'][0]['processingCategory'] = MODULE_SHIPPING_USPSR_LTR_PROCESSING;
+            
+            # Bug fix for letters since the metered rate is four cents less. 
+            $_letter['rates'][0]['price'] += 0.04;
+            $_letter['totalBasePrice'] += 0.04;
             $uspsQuote['rateOptions'][] = $_letter;
         }
 


### PR DESCRIPTION
There's no way to send the Letter request to have a Commercial Rate; it's all set to "RETAIL" by default.

So this bit will literally readd the four cents difference between Metered Mail and Non-Metered Mail.

# Description

<!--Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

<!-- This next line should be left alone so that any related issues are automatically closed. If there is no related issue, delete this next line. If it fixes multiple issues, comma separate them. -->
Fixes # (issue)

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Tested against ZenCart version: (A test passes if it generates no new warnings or errors in ZenCart)

- [x] ZenCart 1.5.5
- [ ] ZenCart 1.5.6
- [ ] ZenCart 1.5.7
- [ ] ZenCart 1.5.8
- [x] ZenCart 2.0.0
- [ ] ZenCart 2.0.1
- [x] ZenCart 2.1.0

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
