### PR TITLE
Update USPS module for PHP 8.5 compatibility

### DIFF
--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -2334,7 +2334,8 @@ class uspsr extends base
         $this->pkgQuote = $this->_makeQuotesCall($pkg_body, 'package-intl');
         $this->ltrQuote = $this->_makeQuotesCall($ltr_body, 'letters-intl');
 
-            $this->notify('NOTIFY_SHIPPING_USPS_INTL_DELIVERY_REQUEST_READY', [], $pkg_body, $ltr_body);
+        $this->notify('NOTIFY_SHIPPING_USPS_INTL_DELIVERY_REQUEST_READY', [], $pkg_body, $ltr_body);
+        
         }
 
         // If the Pricing is Contract, add the Contract Type and AccountNumber
@@ -2392,7 +2393,7 @@ class uspsr extends base
             CURLOPT_VERBOSE => 0,
             CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_TIMEOUT => 15,
-            CURLOPT_USERAGENT => 'ZenCart',
+            CURLOPT_USERAGENT => 'ZenCart v' . PROJECT_VERSION_MAJOR . "." . PROJECT_VERSION_MINOR . " + USPSr Module " . MODULE_SHIPPING_USPSR_VERSION,
         ];
 
         if (CURL_PROXY_REQUIRED === 'True') {
@@ -2422,7 +2423,11 @@ class uspsr extends base
         $this->commInfo = curl_getinfo($ch);
 
         // done with CURL, so close connection
-        curl_close($ch);
+        // Deprecated in PHP 8.5
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
+        
 
         // -----
         // Log the CURL response (will also capture the time the response was received) to capture any
@@ -2548,7 +2553,11 @@ class uspsr extends base
         $this->commInfo = curl_getinfo($ch);
 
         // done with CURL, so close connection
-        curl_close($ch);
+        // Deprecated in PHP 8.5
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
+        
 
         // -----
         // Log the CURL response (will also capture the time the response was received) to capture any
@@ -2626,7 +2635,11 @@ class uspsr extends base
         $this->commInfo = curl_getinfo($ch);
 
         // done with CURL, so close connection
-        curl_close($ch);
+        // Deprecated in PHP 8.5
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
+        
 
         // -----
         // Log the CURL response (will also capture the time the response was received) to capture any


### PR DESCRIPTION
Refactored curl_close calls to avoid deprecated usage in PHP 8.5 by conditionally closing the connection only for PHP versions below 8.0. Also improved the user agent string to include ZenCart and USPSr module versions. Fixed indentation for notify call.

# Description

<!--Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

<!-- This next line should be left alone so that any related issues are automatically closed. If there is no related issue, delete this next line. If it fixes multiple issues, comma separate them. -->
Fixes #81 

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Tested against ZenCart version: (A test passes if it generates no new warnings or errors in ZenCart)

- [x] ZenCart 1.5.5
- [x] ZenCart 1.5.6
- [x] ZenCart 1.5.7
- [x] ZenCart 1.5.8
- [x] ZenCart 2.0.0
- [x] ZenCart 2.0.1
- [x] ZenCart 2.1.0
- [x] ZenCart 2.2.0-dev

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
