### PR TITLE
Fix variable reference and code formatting in uspsr.php

### DIFF
--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -725,7 +725,7 @@ class uspsr extends base
                         foreach ($services as $s) {
                             if (isset($lookup[$method_name]['extraService'][$s]['price'])) {
                                 $method_price = $lookup[$method_name]['extraService'][$s]['price'];
-                                $extraServices += $price;
+                                $extraServices += $method_price;
 
                                 // Add service name if available, otherwise fall back to the code
                                 $label = $lookup[$method_name]['extraService'][$s]['name'] ?? $s;
@@ -2326,7 +2326,7 @@ class uspsr extends base
                 'itemValue' => (MODULE_SHIPPING_USPSR_DISPATCH_CART_TOTAL == "Yes" ? $this->shipment_value : 5),
             ];
 
-                        // Letter Request Body
+            // Letter Request Body
             $ltr_body = [
                 "weight" => $shipping_weight,
                 "length" => $this->dimensions['ltr_length'],
@@ -2355,12 +2355,12 @@ class uspsr extends base
             }
 
 
-        // Send pkg_body to make pkgQuote.
-        $this->pkgQuote = $this->_makeQuotesCall($pkg_body, 'package-intl');
-        $this->ltrQuote = $this->_makeQuotesCall($ltr_body, 'letters-intl');
+			// Send pkg_body to make pkgQuote.
+			$this->pkgQuote = $this->_makeQuotesCall($pkg_body, 'package-intl');
+			$this->ltrQuote = $this->_makeQuotesCall($ltr_body, 'letters-intl');
 
-        $this->notify('NOTIFY_SHIPPING_USPS_INTL_DELIVERY_REQUEST_READY', [], $pkg_body, $ltr_body);
-        
+			$this->notify('NOTIFY_SHIPPING_USPS_INTL_DELIVERY_REQUEST_READY', [], $pkg_body, $ltr_body);
+			
         }
 
         // If the Pricing is Contract, add the Contract Type and AccountNumber
@@ -2386,9 +2386,6 @@ class uspsr extends base
             
 
         }
-
-        // If there is a request for either version of letter, send that request.
-
     }
 
     protected function _makeStandardsCall($query)


### PR DESCRIPTION
# Description

Corrects the variable used for extra service price calculation and improves indentation and comment formatting in international delivery request logic for USPSRestful shipping module.

Fixes #91

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Tested against ZenCart version: (A test passes if it generates no new warnings or errors in ZenCart)

- [x] ZenCart 1.5.5
- [x] ZenCart 1.5.6
- [x] ZenCart 1.5.7
- [x] ZenCart 1.5.8
- [x] ZenCart 2.0.0
- [x] ZenCart 2.0.1
- [x] ZenCart 2.1.0
- [ ] ZenCart 2.2.0-dev

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
