### PR TITLE
Add handling time to USPS transit estimates

### DIFF
--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/functions/extra_functions/usps.extra_functions.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/functions/extra_functions/usps.extra_functions.php
@@ -705,14 +705,30 @@ function uspsr_get_connect_zipcodes($data)
 function zen_uspsr_estimate_days($data)
 {
     $output = '';
+
+    if (!defined('MODULE_SHIPPING_USPSR_HANDLING_TIME')) {
+        return $data;
+    }
+
+    $daystoadd = (int) MODULE_SHIPPING_USPSR_HANDLING_TIME;
+
     // Simply put, put the number before the word.
     if (preg_match("/\d+\-\d+/", $data)) {
-        $output = $data . " " . MODULE_SHIPPING_USPSR_TEXT_DAYS;
-    } elseif (is_numeric($data) && ($data > 1 || $data == 0))
-        $output = $data . " " . MODULE_SHIPPING_USPSR_TEXT_DAYS;
-    else
-        $output = "~" . $data . " " . MODULE_SHIPPING_USPSR_TEXT_DAY;
 
+        // Split the range of days off and add the handling time to each end.
+        $days = explode('-', $data);
+        foreach ($days as &$day) {
+            $day = (int)$day + $daystoadd;
+        }
+        $data = implode('-', $days); // Collapse the array back into a - string. (This should still only have two values)
+        $output = $data . " " . MODULE_SHIPPING_USPSR_TEXT_DAYS;
+
+    } elseif (is_numeric($data) && ($data > 1 || $data == 0)) {
+        $output = (int)$data + $daystoadd . " " . MODULE_SHIPPING_USPSR_TEXT_DAYS;
+    } else {
+        $days = (int)$data + $daystoadd;
+        $output = "~" . $days . " " . ($days == 1 ? MODULE_SHIPPING_USPSR_TEXT_DAY : MODULE_SHIPPING_USPSR_TEXT_DAYS);
+    }
 
     return $output;
 }

--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -785,6 +785,24 @@ class uspsr extends base
                         $quote_message .= "\n" . 'Adding option : ' . $quotes['title'] . "\n";
                         $quote_message .= 'Price From Quote : ' . $currencies->format($lookup[$method_item['method']]['totalBasePrice']) . " , Method Handling : " . $currencies->format((double) $method_item['handling']) . " , Order Handling : " . $currencies->format($usps_handling_fee) . " , Extra Services: " . $currencies->format($extraServices) . "\n";
                         $quote_message .= "Final Price (Quote + Handling + Order Handling + Services) * # of Boxes ($shipping_num_boxes) : " . $currencies->format($price) . "\n";
+
+                        if ($this->is_us_shipment && isset($uspsStandards[$quotes['mailClass']])) { // Only do this for domestic shipments
+                            // If there is a standards request, add that line:
+                            switch (MODULE_SHIPPING_USPSR_DISPLAY_TRANSIT) 
+                            {
+                                case "Estimate Transit Time": 
+                                    $total_days = (int)$uspsStandards[$quotes['mailClass']]['serviceStandard'] + (int) MODULE_SHIPPING_USPSR_HANDLING_TIME;
+                                    $quote_message .= "Estimated Transit Time per Standards: " . (int)$uspsStandards[$quotes['mailClass']]['serviceStandard']  . " day(s) + Handling Days: " . (int) MODULE_SHIPPING_USPSR_HANDLING_TIME . " day(s) = Total Days: " . $total_days . " day(s)" . "\n";
+                                    break;
+                                case "Estimate Delivery":
+                                    $est_delivery_raw = new DateTime($uspsStandards[$quotes['mailClass']]['delivery']['scheduledDeliveryDateTime']);
+                                    $est_delivery = $est_delivery_raw->format(DATE_FORMAT);
+
+                                    $quote_message .= "Estimated Delivery Date per Standards:" . $est_delivery . "\n";
+                                    break;
+                            }
+                        }
+
                     } elseif (!$match) {
                         // Order failed to match
                         $quote_message .= "\n" . 'Skipping the method :"' . $quotes['title'] . '" because it did not match the target.' . "\n";


### PR DESCRIPTION
# Description

- Updated usps.extra_functions.php to include handling time in estimated delivery days calculations.
- Added the calculation and delivery date estimate to the log file for display

<!-- This next line should be left alone so that any related issues are automatically closed. If there is no related issue, delete this next line. If it fixes multiple issues, comma separate them. -->
Fixes #90

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Tested against ZenCart version: (A test passes if it generates no new warnings or errors in ZenCart)

- [ ] ZenCart 1.5.5
- [ ] ZenCart 1.5.6
- [ ] ZenCart 1.5.7
- [x] ZenCart 1.5.8
- [ ] ZenCart 2.0.0
- [ ] ZenCart 2.0.1
- [x] ZenCart 2.1.0
- [ ] ZenCart 2.2.0-dev

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
