### PR TITLE
Attempt at preventing fatal error from bad response

### DIFF
--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -2373,12 +2373,12 @@ class uspsr extends base
             }
 
 
-			// Send pkg_body to make pkgQuote.
-			$this->pkgQuote = $this->_makeQuotesCall($pkg_body, 'package-intl');
-			$this->ltrQuote = $this->_makeQuotesCall($ltr_body, 'letters-intl');
+            // Send pkg_body to make pkgQuote.
+            $this->pkgQuote = $this->_makeQuotesCall($pkg_body, 'package-intl');
+            $this->ltrQuote = $this->_makeQuotesCall($ltr_body, 'letters-intl');
 
-			$this->notify('NOTIFY_SHIPPING_USPS_INTL_DELIVERY_REQUEST_READY', [], $pkg_body, $ltr_body);
-			
+            $this->notify('NOTIFY_SHIPPING_USPS_INTL_DELIVERY_REQUEST_READY', [], $pkg_body, $ltr_body);
+            
         }
 
         // If the Pricing is Contract, add the Contract Type and AccountNumber
@@ -2393,15 +2393,18 @@ class uspsr extends base
 
         // Are we looking up the time frames? If not, don't send the request for Standards
         if (defined('MODULE_SHIPPING_USPSR_DISPLAY_TRANSIT') && MODULE_SHIPPING_USPSR_DISPLAY_TRANSIT !== 'No' && $this->is_us_shipment) {
-
+            $standards_response = json_decode($this->_makeStandardsCall($standards_query), TRUE);
             
-            foreach (json_decode($this->_makeStandardsCall($standards_query), TRUE) as $item) {
-                $this->uspsStandards[$item['mailClass']] = $item;
+            if (is_array($standards_response)) {
+                foreach ($standards_response as $item) {
+                    if (is_array($item) && isset($item['mailClass'])) {
+                        $this->uspsStandards[$item['mailClass']] = $item;
+                    }
+                }
             }
-            
+
             // Holdover observer, instead of modifiying the request, you'll modify the result. Use a DEBUG file to see what is available to modify.
             $this->notify('NOTIFY_SHIPPING_USPS_CUSTOM_TRANSIT_TIME', $this->uspsStandards);
-            
 
         }
     }


### PR DESCRIPTION
# Description

Refactored the handling of the standards response to ensure it is an array before iterating, and added checks for array structure and 'mailClass' key. This prevents potential errors when the response is not as expected.

<!-- This next line should be left alone so that any related issues are automatically closed. If there is no related issue, delete this next line. If it fixes multiple issues, comma separate them. -->
Fixes #93 

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Tested against ZenCart version: (A test passes if it generates no new warnings or errors in ZenCart)

- [ ] ZenCart 1.5.5
- [ ] ZenCart 1.5.6
- [ ] ZenCart 1.5.7
- [x] ZenCart 1.5.8
- [ ] ZenCart 2.0.0
- [ ] ZenCart 2.0.1
- [ ] ZenCart 2.1.0
- [ ] ZenCart 2.2.0-dev

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
