### PR TITLE
Add uspsr_read_only function and update config usage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed in [UNRELEASED]
 
-- The module will no longer try to blindly add new configuration keys. Instead, it will check to see if the database key exists first and then try to insert it if it finds no match.
+- The module will no longer try to blindly add new configuration keys. Instead, it will check to see if the database key exists first and then try to insert it if it finds no match. Otherwise, it will update the value instead.
 
 ## 1.6.1 - 2025-12-18
 

--- a/zc_plugins/USPSRestful/v0.0.0/admin/includes/functions/extra_functions/usps.extra_functions.php
+++ b/zc_plugins/USPSRestful/v0.0.0/admin/includes/functions/extra_functions/usps.extra_functions.php
@@ -52,3 +52,13 @@ if (file_exists(DIR_FS_CATALOG . DIR_WS_FUNCTIONS . 'extra_functions/usps.extra_
             . 'catalog/' . DIR_WS_FUNCTIONS . 'extra_functions/usps.extra_functions.php';
     } 
 }
+
+
+// For some reason, the module was trying to use this function, but loading it with hidden values was gunking it up.
+function uspsr_read_only($text, $key = '')
+{
+    $name = (!empty($key)) ? 'configuration[' . $key . ']' : 'configuration_value';
+    $text = htmlspecialchars_decode($text, ENT_COMPAT);
+
+    return $text;
+}

--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -1020,7 +1020,7 @@ class uspsr extends base
             'configuration_description' => 'You have installed:',
             'configuration_group_id' => 6,
             'sort_order' => 0,
-            'set_function' => 'zen_cfg_read_only( ',
+            'set_function' => 'uspsr_read_only( ',
             'date_added' => 'now()',
         ]);
 
@@ -2116,7 +2116,7 @@ class uspsr extends base
             // After all this, update the modules version number as necessary.
             $this->updateConfigurationKey('MODULE_SHIPPING_USPSR_VERSION', [
                 'configuration_value' => self::USPSR_CURRENT_VERSION,
-                'set_function' => "zen_cfg_read_only("
+                'set_function' => "uspsr_read_only("
 
             ]);
 


### PR DESCRIPTION
# Description

Introduces the uspsr_read_only function to replace zen_cfg_read_only for configuration display in the USPSRestful module. Updates references in uspsr.php to use the new function, addressing issues with hidden values. (For some reason, the hidden value was causing issues. I don't know why.)

Fixes #78 

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Tested against ZenCart version: (A test passes if it generates no new warnings or errors in ZenCart)

- [x] ZenCart 1.5.5
- [ ] ZenCart 1.5.6
- [ ] ZenCart 1.5.7
- [ ] ZenCart 1.5.8
- [x] ZenCart 2.0.0
- [ ] ZenCart 2.0.1
- [x] ZenCart 2.1.0
- [ ] ZenCart 2.2.0-dev

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
