### PR TITLE
Adding service estimations to international shipments

### DIFF
--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/languages/english/modules/shipping/lang.uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/languages/english/modules/shipping/lang.uspsr.php
@@ -40,6 +40,7 @@ $define = [
     'MODULE_SHIPPING_USPSR_TEXT_ESTIMATED' => 'est.',
     'MODULE_SHIPPING_USPSR_TEXT_ESTIMATED_DELIVERY' => 'est. delivery',
 
+    'MODULE_SHIPPING_USPSR_TEXT_VARIES_BY_DESTINATION' => 'varies by destination country',
 ];
 
 return $define;

--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/languages/english/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/languages/english/modules/shipping/uspsr.php
@@ -39,3 +39,4 @@ define('MODULE_SHIPPING_USPSR_TEXT_WEEKS' , 'weeks');
 define('MODULE_SHIPPING_USPSR_TEXT_VARIES' , 'Varies');
 define('MODULE_SHIPPING_USPSR_TEXT_ESTIMATED' , 'est.');
 define('MODULE_SHIPPING_USPSR_TEXT_ESTIMATED_DELIVERY' , 'est. delivery');
+define('MODULE_SHIPPING_USPSR_TEXT_VARIES_BY_DESTINATION' , 'varies by destination country');

--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -920,7 +920,7 @@ class uspsr extends base
                     switch (MODULE_SHIPPING_USPSR_DISPLAY_TRANSIT) {
                         case "Estimate Transit Time":
                             foreach ($build_quotes as &$quote) {
-                                if (isset($uspsStandards[$quote['mailClass']]['serviceStandard'])) $quote['title'] .= " [" . MODULE_SHIPPING_USPSR_TEXT_ESTIMATED . " " . zen_uspsr_estimate_days($uspsStandards[$quote['mailClass']]['serviceStandard']) . "]";
+                                if (isset($uspsStandards[$quote['mailClass']]['serviceStandard'])) $quote['title'] .= " (" . MODULE_SHIPPING_USPSR_TEXT_ESTIMATED . " " . zen_uspsr_estimate_days($uspsStandards[$quote['mailClass']]['serviceStandard']) . ")";
                             }
                             break;
                         case "Estimate Delivery":
@@ -930,7 +930,7 @@ class uspsr extends base
                                     $est_delivery_raw = new DateTime($uspsStandards[$quote['mailClass']]['delivery']['scheduledDeliveryDateTime']);
                                     $est_delivery = $est_delivery_raw->format(DATE_FORMAT);
 
-                                    $quote['title'] .= " [" . MODULE_SHIPPING_USPSR_TEXT_ESTIMATED_DELIVERY . " " . $est_delivery . "]";
+                                    $quote['title'] .= " (" . MODULE_SHIPPING_USPSR_TEXT_ESTIMATED_DELIVERY . " " . $est_delivery . ")";
                                 }
                             }
                             break;
@@ -940,7 +940,7 @@ class uspsr extends base
                 switch (MODULE_SHIPPING_USPSR_DISPLAY_TRANSIT) {
                     case "Estimate Transit Time":
                         foreach ($build_quotes as &$quote) {
-                            $quote['title'] .= " [" . MODULE_SHIPPING_USPSR_TEXT_ESTIMATED . " " . zen_uspsr_estimate_days("8-30") . ", varies by destination country" . "]";
+                            $quote['title'] .= " (" . MODULE_SHIPPING_USPSR_TEXT_ESTIMATED . " " . zen_uspsr_estimate_days("8-30") . ", " . MODULE_SHIPPING_USPSR_TEXT_VARIES_BY_DESTINATION .  ")";
                         }
                         break;
                     case "Estimate Delivery":
@@ -955,7 +955,7 @@ class uspsr extends base
                             $late = new DateTime();
                             $late->modify("+$latest_handling days");
 
-                            $quote['title'] .= " [" . MODULE_SHIPPING_USPSR_TEXT_ESTIMATED_DELIVERY . " " . $early->format(DATE_FORMAT) . " - " . $late->format(DATE_FORMAT) . ", varies by destination country]";
+                            $quote['title'] .= " (" . MODULE_SHIPPING_USPSR_TEXT_ESTIMATED_DELIVERY . " " . $early->format(DATE_FORMAT) . "-" . $late->format(DATE_FORMAT) . ", " . MODULE_SHIPPING_USPSR_TEXT_VARIES_BY_DESTINATION . ")";
                         }
                         break;
                 }


### PR DESCRIPTION
# Description

Refactored logic to better distinguish between domestic and international shipments when displaying estimated transit times and delivery dates. International shipments will estimate between 8 days and as much as 30 days.

<!-- This next line should be left alone so that any related issues are automatically closed. If there is no related issue, delete this next line. If it fixes multiple issues, comma separate them. -->
Closes #105 

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Tested against ZenCart version: (A test passes if it generates no new warnings or errors in ZenCart)

- [x] ZenCart 1.5.5
- [x] ZenCart 1.5.6
- [x] ZenCart 1.5.7
- [x] ZenCart 1.5.8
- [x] ZenCart 2.0.0
- [x] ZenCart 2.0.1
- [x] ZenCart 2.1.0
- [x] ZenCart 2.2.0-dev

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
