### PR TITLE
Fix to International rates being missing again

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Refactor the version checker and updater (instead of branching the versions, just check to see if the key in question is installed.)
 - Refactor code to support PHP 5.x. _(Editor Note: This will be a separate repo.)_
 - Work on incorporating into Advanced Shipping Manager.
+- Moving selection of add-ons (ie. Certified Mail, etc.) to a separate control panel.
+- Moving add-ons to separate order-total line?
 
 ## [UNRELEASED] - 0000-00-00
 
@@ -17,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Fixed a minor formatting issue that resulted in some HTML entities being logged as part of the debug log.
 - Clarified the encapsulated uninstaller to look specifically for a file named uspsr.php. (Not uspsr(some character).php).
+- Fixed an issue (again) with the display of Priority Mail rates that were being hidden because of an uncaught Machinable/Nonstandard flag. This should work as necessary. This might pop up in other services, will keep an eye on it. [[#109](https://github.com/retched/ZC-USPSRestful/issues/109)]
 
 ## 1.7.0 - 2026-01-19
 

--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -349,23 +349,6 @@ class uspsr extends base
                 break;
         }
 
-        /**
-         * Determine if package is machinable or not - Media Mail Only
-         * API will either return both the machinable rate and non-machinable rate or one or the other.
-         *
-         * The store owner will choose a preference. If the preference can be met, show that rate. If it can't be met, but there is only
-         * one rate available... show THAT rate.
-         *
-         * By definition, Media Mail Machinable parcels must weight less than 25lbs with no minimum. Additionally, a package to be machineable
-         * cannot be more than 22 inches long, 18 inches wide, 15 inches high. The USPS considers the longest measurement given to the length, the
-         * 2nd longest measurement is considered it's width, and the third longest it's height. (Actually it considers "length is the measurement of
-         * the longest dimension and girth is the distance around the thickest part".)
-         *
-         * If all else fails, follow the module setting.
-         *
-         * For all other services, this is handled by the API.
-         */
-
         // Rebuild the dimmensions array
         $pkg_dimensions = array_filter(explode(', ', MODULE_SHIPPING_USPSR_DIMMENSIONS));
         array_walk($pkg_dimensions, function (&$value) {

--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -662,6 +662,15 @@ class uspsr extends base
                     if (strpos($name, "Connect Local") !== FALSE) $rate['productName'] = $rate['description'];
 
                     // ---------------------------------------------
+                    // Priority Mail Internationals
+                    // Drop the Machniable / Nonstandard indicators and just call it "Priority Mail (Express) International ISC Single-piece" since the API doesn't always return those in a consistent way.
+                    // ---------------------------------------------
+                    if (preg_match('/Priority Mail( Express)? International (Nonstandard|Machinable) ISC Single-piece/', $name, $matches)) {
+                        $name = "Priority Mail" . ($matches[1] ?? '') . " International ISC Single-piece";
+                        $rate['productName'] = $name;
+                    }
+
+                    // ---------------------------------------------
                     // Default: All is OK, add it to the list
                     // ---------------------------------------------
                     $lookup[$name] = $rate;
@@ -711,7 +720,6 @@ class uspsr extends base
                     $match = TRUE;
                     $made_weight = FALSE;
                     $quote_message = '';
-                    $services_total = 0;
 
                     // If this package is NOT going to an APO/FPO/DPO, skip and continue to the next
                     // Currently this is the only rate which has a different rate for APO/FPO/DPO rates.


### PR DESCRIPTION
# Description

<!--Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Fixes the Priority Mail International bug by removing the Machinable/Nonstandard flag that's a part of the API request.

<!-- This next line should be left alone so that any related issues are automatically closed. If there is no related issue, delete this next line. If it fixes multiple issues, comma separate them. -->
Fixes #109 

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Tested against ZenCart version: (A test passes if it generates no new warnings or errors in ZenCart)

- [x] ZenCart 1.5.5
- [x] ZenCart 1.5.6
- [x] ZenCart 1.5.7
- [x] ZenCart 1.5.8
- [x] ZenCart 2.0.0
- [x] ZenCart 2.0.1
- [x] ZenCart 2.1.0
- [ ] ZenCart 2.2.0-dev

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
