### PR TITLE
Remove unneeded zen_draw_label

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,9 +13,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Moving add-ons to separate order-total line?
 - Add warning about being on the "weakest" allotment of API pulls (aka "Public Support I"). Provide user instructions on how to upgrade tiers.
 
-## [UNRELEASED] - 0000-00-00
+## 1.8.2 - 2026-02-24
 
-### Fixed in [UNRELEASED]
+### Fixed in 1.8.2
+
+- Fixed a white screen crash caused by the redeclaration of `zen_draw_label` that was meant for the PHP5 version of module. [[#117](https://github.com/retched/ZC-USPSRestful/issues/117)]
+
+## 1.8.1 - 2026-02-21
+
+### Fixed in 1.8.1
 
 - Improved the uninstall script (`?cmd=uspsr_uninstall`) and purge (`?cmd=uspsr_purge`) scripts to run in the backend via either a link in the menu (traditional only) or direct access in the backend (traditional and encapsulated). This script is SEVERELY powerful. You MUST confirm that you want to run this script. (Which was noticebly absent on the first launch.) The "extras" folder version will still be available for advanced users and will not be included in the ZenCart Plugins Database release. (Will still be available on the GitHub repository.)
 - Fixed the weight checking algorithm that was introduced in 1.8.0. Older versions of ZenCart only have the `$order->products[$x]['weight']` field instead of `$order->products[$x]['products_weight']` that was being used. This caused an issue in earlier versions of ZenCart that didn't have that value set and thus was zero'd out which would mean the module has a zero weight.

--- a/zc_plugins/USPSRestful/v0.0.0/admin/includes/functions/extra_functions/usps.extra_functions.php
+++ b/zc_plugins/USPSRestful/v0.0.0/admin/includes/functions/extra_functions/usps.extra_functions.php
@@ -62,11 +62,3 @@ function uspsr_read_only($text, $key = '')
 
     return $text;
 }
-
-if (!function_exists('zen_draw_label')) { // Introduced in ZC 1.5.5
-  function zen_draw_label($text, $for, $parameters = ''){
-    $label = '<label for="' . $for . '" ' . $parameters . '>' . $text . '</label>';
-    return $label;
-  }
-
-}


### PR DESCRIPTION
Removing the unneeded zen_draw_label as it's been available in ZC 1.5.4 and up. (This causes a white-screen crash (fixes #117) and keeps the module compatible with the PHP/ZenCart environment.)

# Description

<!--Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

<!-- This next line should be left alone so that any related issues are automatically closed. If there is no related issue, delete this next line. If it fixes multiple issues, comma separate them. -->
Fixes # (issue)

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Tested against ZenCart version: (A test passes if it generates no new warnings or errors in ZenCart)

- [ ] ZenCart 1.5.5
- [ ] ZenCart 1.5.6
- [ ] ZenCart 1.5.7
- [ ] ZenCart 1.5.8
- [ ] ZenCart 2.0.0
- [ ] ZenCart 2.0.1
- [x] ZenCart 2.1.0
- [ ] ZenCart 2.2.0-dev

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
