### PR TITLE
Prevent duplicate USPSr admin-page install

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## Fixed in [UNRELEASED]
 
 - Fixed an issue that would generate PHP warning messages when a certain extraService was returned with no "extraService" code in the API. Resolved that by assigning it a psuedo-code and gave it a selection in the admin area. (This is a temporary fix until the API inevitably changes and gives it a number.) [[#120](https://github.com/retched/ZC-USPSRestful/issues/120)]
+- Fixed an issue that had the USPSr module try to run the DB call to install the Tools menu link to add the installer twice. (Once on upgrade and once on the same initial run.) Since the "Define" wasn't properly in place, it effectively tried to go at it twice. This generated an error. Now the module will check to see if the admin page exists first (using the ZenCart function `zen_page_key_exists`), and if it doesn't, THEN try to install the module link. [[#121](https://github.com/retched/ZC-USPSRestful/issues/121)]
 
 ## 1.8.2 - 2026-02-24
 

--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -1605,11 +1605,11 @@ class uspsr extends base
             'date_added' => 'now()'
         ]);
 
-        if (!defined('MODULE_SHIPPING_USPSR_INSTALL')) {
+        if (!defined('MODULE_SHIPPING_USPSR_INSTALL') && !zen_page_key_exists('uspsrUninstall')) {
             // The "_INSTALL" flag was not defined, so this means this is not an encapsulated install.
             // Add the Admin Page link for the module's uninstallation.
             global $db;
-            $db->Execute("INSERT INTO " . TABLE_ADMIN_PAGES . " (page_key, language_key, main_page, page_params, menu_key, display_on_menu, sort_order) VALUES ('uspsrUninstall', 'BOX_USPSR_UNINSTALLER', 'FILENAME_USPS_UNINSTALL', '', 'tools', 'Y', 14000)");
+            $db->Execute("INSERT IGNORE INTO " . TABLE_ADMIN_PAGES . " (page_key, language_key, main_page, page_params, menu_key, display_on_menu, sort_order) VALUES ('uspsrUninstall', 'BOX_USPSR_UNINSTALLER', 'FILENAME_USPS_UNINSTALL', '', 'tools', 'Y', 14000)");
         }
 
         $this->notify('NOTIFY_SHIPPING_USPS_INSTALLED');
@@ -2211,11 +2211,14 @@ class uspsr extends base
                 case "v1.6.1": // Released 2025-12-19: No further changes
                 case "v1.6.2": // Released 2025-12-20: No further changes
                 case "v1.7.0": // Released 2026-01-19: No database changes, only adding in a new Admin Page for the uninstallation of the module.
-                    if (!defined('MODULE_SHIPPING_USPSR_INSTALL')) {
+                case "v1.8.0": // Released 2026-02-18: No changes, but this is a repair release
+                case "v1.8.1": // Released 2026-02-21: No changes, but this is a repair release
+                case "v1.8.2": // Released 2026-02-24: No changes, but this is a repair release
+                    if (!defined('MODULE_SHIPPING_USPSR_INSTALL') && !zen_page_key_exists('uspsrUninstall')) {
                         // The "_INSTALL" flag was not defined, so this means this is not an encapsulated install.
                         // Add the Admin Page link for the module's uninstallation.
                         global $db;
-                        $db->Execute("INSERT INTO " . TABLE_ADMIN_PAGES . " (page_key, language_key, main_page, page_params, menu_key, display_on_menu, sort_order) VALUES ('uspsrUninstall', 'BOX_USPSR_UNINSTALLER', 'FILENAME_USPS_UNINSTALL', '', 'tools', 'Y', 600)");
+                        $db->Execute("INSERT IGNORE INTO " . TABLE_ADMIN_PAGES . " (page_key, language_key, main_page, page_params, menu_key, display_on_menu, sort_order) VALUES ('uspsrUninstall', 'BOX_USPSR_UNINSTALLER', 'FILENAME_USPS_UNINSTALL', '', 'tools', 'Y', 600)");
                     }
                     break;
             }


### PR DESCRIPTION
# Description

Removes the possibility of a key conflict by checking to see if the page key for the uninstaller exists first before trying to readd it.

<!--Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

<!-- This next line should be left alone so that any related issues are automatically closed. If there is no related issue, delete this next line. If it fixes multiple issues, comma separate them. -->
Fixes #121 

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Tested against ZenCart version: (A test passes if it generates no new warnings or errors in ZenCart)

- [ ] ZenCart 1.5.5
- [ ] ZenCart 1.5.6
- [ ] ZenCart 1.5.7
- [x] ZenCart 1.5.8
- [x] ZenCart 2.0.0
- [x] ZenCart 2.0.1
- [ ] ZenCart 2.1.0
- [ ] ZenCart 2.2.0-dev

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
