### PR TITLE
Fix USPSR uninstall page

### DIFF
--- a/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
+++ b/zc_plugins/USPSRestful/v0.0.0/catalog/includes/modules/shipping/uspsr.php
@@ -1609,7 +1609,7 @@ class uspsr extends base
             // The "_INSTALL" flag was not defined, so this means this is not an encapsulated install.
             // Add the Admin Page link for the module's uninstallation.
             global $db;
-            $db->Execute("INSERT IGNORE INTO " . TABLE_ADMIN_PAGES . " (page_key, language_key, main_page, page_params, menu_key, display_on_menu, sort_order) VALUES ('uspsrUninstall', 'BOX_USPSR_UNINSTALLER', 'FILENAME_USPS_UNINSTALL', '', 'tools', 'Y', 14000)");
+            $db->Execute("INSERT IGNORE INTO " . TABLE_ADMIN_PAGES . " (page_key, language_key, main_page, page_params, menu_key, display_on_menu, sort_order) VALUES ('uspsrUninstall', 'BOX_USPSR_UNINSTALLER', 'FILENAME_USPSR_UNINSTALL', '', 'tools', 'Y', 14000)");
         }
 
         $this->notify('NOTIFY_SHIPPING_USPS_INSTALLED');
@@ -1675,7 +1675,7 @@ class uspsr extends base
 
         // Redirect to the Admin Page link for the module's final uninstallation.
         if (!defined('MODULE_SHIPPING_USPSR_INSTALL')) {
-            $messageStack->add_session('The module USPSr has been uninstalled and disabled. If you want to delete the files, you can visit the USPS Uninstaller to remove all associated files. Visit the <a href="' . zen_href_link(FILENAME_USPS_UNINSTALL) . '">USPSr Removal Tool</a> for additional steps.', 'success');
+            $messageStack->add_session('The module USPSr has been uninstalled and disabled. If you want to delete the files, you can visit the USPS Uninstaller to remove all associated files. Visit the <a href="' . zen_href_link(FILENAME_USPSR_UNINSTALL) . '">USPSr Removal Tool</a> for additional steps.', 'success');
         }
     }
 
@@ -2218,11 +2218,15 @@ class uspsr extends base
                 case "v1.8.0": // Released 2026-02-18: No changes, but this is a repair release
                 case "v1.8.1": // Released 2026-02-21: No changes, but this is a repair release
                 case "v1.8.2": // Released 2026-02-24: No changes, but this is a repair release
+                case "v1.8.3": // Released 2026-02-25: No changes, but this is a repair release
                     if (!defined('MODULE_SHIPPING_USPSR_INSTALL') && !zen_page_key_exists('uspsrUninstall')) {
                         // The "_INSTALL" flag was not defined, so this means this is not an encapsulated install.
                         // Add the Admin Page link for the module's uninstallation.
                         global $db;
-                        $db->Execute("INSERT IGNORE INTO " . TABLE_ADMIN_PAGES . " (page_key, language_key, main_page, page_params, menu_key, display_on_menu, sort_order) VALUES ('uspsrUninstall', 'BOX_USPSR_UNINSTALLER', 'FILENAME_USPS_UNINSTALL', '', 'tools', 'Y', 600)");
+                        $db->Execute("INSERT IGNORE INTO " . TABLE_ADMIN_PAGES . " (page_key, language_key, main_page, page_params, menu_key, display_on_menu, sort_order) VALUES ('uspsrUninstall', 'BOX_USPSR_UNINSTALLER', 'FILENAME_USPSR_UNINSTALL', '', 'tools', 'Y', 600)");
+                    } else {
+                        global $db;
+                        $db->Execute("UPDATE " . TABLE_ADMIN_PAGES . " SET main_page = 'FILENAME_USPSR_UNINSTALL' WHERE page_key = 'uspsrUninstall'");
                     }
                     break;
             }


### PR DESCRIPTION
# Description

Corrects incorrect uninstall filename references and admin page handling for the USPSR shipping module. Replaces 'FILENAME_USPS_UNINSTALL' with 'FILENAME_USPSR_UNINSTALL' in admin page inserts and the uninstall success message link. Adds a v1.8.3 upgrade case that inserts the admin page if missing and updates the existing admin_pages entry to point to the correct main_page when present, preventing broken links to the USPSr removal tool.

<!-- This next line should be left alone so that any related issues are automatically closed. If there is no related issue, delete this next line. If it fixes multiple issues, comma separate them. -->
Fixes # (issue)

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Tested against ZenCart version: (A test passes if it generates no new warnings or errors in ZenCart)

- [x] ZenCart 1.5.5
- [x] ZenCart 1.5.6
- [x] ZenCart 1.5.7
- [x] ZenCart 1.5.8
- [ ] ZenCart 2.0.0
- [x] ZenCart 2.0.1
- [ ] ZenCart 2.1.0
- [ ] ZenCart 2.2.0-dev

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
